### PR TITLE
Custom pages support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ UI language in Sanity schemas is Hungarian. Code language is English.
 - Schema field titles in Hungarian, field names in English camelCase
 - Always add `validation: (Rule) => Rule.required()` unless a field is intentionally optional
 - Use `createSlugWithUrlInput(basePath)` for slug fields
+- Use emoji functions for schema icons (e.g. `icon: () => '🗂️'`), not `@sanity/icons`
 
 ### Sanity Queries
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# Green Point Beauty - Claude Instructions
+
+## Project Overview
+
+Next.js 16 (App Router) + Sanity v4 CMS website for a Hungarian beauty salon.
+UI language in Sanity schemas is Hungarian. Code language is English.
+
+## Tech Stack
+
+- Next.js 16 with App Router and Turbopack
+- React 19
+- TypeScript (strict)
+- Sanity v4 (headless CMS)
+- Tailwind CSS v4
+- Radix UI primitives
+- Lucide React for icons
+
+## Code Style
+
+### General
+
+- Use named exports for all components (not default exports, except Next.js page files which require default exports)
+- Use `const` arrow functions for components
+- Never use `any` in TypeScript
+- Imports: external packages first, then internal `@/` imports, separated by a blank line
+
+### Components
+
+- No inline prop types, separate `type` always.
+- Use `cn()` from `@/lib/utils` for conditional Tailwind classes
+- Layout structure for pages: `<main>` wrapping `<Container>`, with `<BackgroundShapes />` and `<Footer />` included
+
+### Sanity Schemas
+
+- Use `defineType` and `defineField` from `'sanity'`
+- Schema field titles in Hungarian, field names in English camelCase
+- Always add `validation: (Rule) => Rule.required()` unless a field is intentionally optional
+- Use `createSlugWithUrlInput(basePath)` for slug fields
+
+### Sanity Queries
+
+- Define queries as `const` with `defineQuery()` from `'next-sanity'`, SCREAMING_SNAKE_CASE name ending in `_QUERY`
+- Wrap fetch functions with `sanityFetch` from `@/sanity/lib/live`
+- Export fetch functions named `fetch[Resource][ByX]`
+
+### Tailwind
+
+- Use the custom `fuego` color palette (e.g. `text-fuego-900`, `bg-fuego-100`)
+- Mobile-first responsive design with `lg:` breakpoint as the primary desktop breakpoint
+
+## Project Structure
+
+- `src/app/` - Next.js app routes and components
+- `src/app/components/` - Shared UI components
+- `src/app/components/ui/` - Low-level UI primitives (Radix-based)
+- `src/sanity/schemaTypes/` - Sanity document and field types
+- `src/sanity/lib/` - Sanity client, queries, image helpers
+- `src/lib/utils.ts` - Shared utilities (`cn`, etc.)
+
+## After making schema changes
+
+Run `npm run typegen` to regenerate TypeScript types from the Sanity schema.

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -13,6 +13,42 @@
  */
 
 // Source: schema.json
+export type Navigation = {
+  _id: string;
+  _type: 'navigation';
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  navMenuItems?: Array<{
+    label?: string;
+    mode?: 'link' | 'group';
+    linkType?: 'internal' | 'external';
+    internalLink?:
+      | {
+          _ref: string;
+          _type: 'reference';
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: 'treatment';
+        }
+      | {
+          _ref: string;
+          _type: 'reference';
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: 'customPage';
+        };
+    externalLink?: string;
+    referencedTreatments?: Array<{
+      _ref: string;
+      _type: 'reference';
+      _weak?: boolean;
+      _key: string;
+      [internalGroqTypeReferenceTo]?: 'treatment';
+    }>;
+    _type: 'navMenuItem';
+    _key: string;
+  }>;
+};
+
 export type CustomPage = {
   _id: string;
   _type: 'customPage';
@@ -37,35 +73,6 @@ export type CustomPage = {
     }>;
     level?: number;
     _type: 'block';
-    _key: string;
-  }>;
-};
-
-export type Navigation = {
-  _id: string;
-  _type: 'navigation';
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  navMenuItems?: Array<{
-    label?: string;
-    mode?: 'link' | 'group';
-    linkType?: 'internal' | 'external';
-    internalLink?: {
-      _ref: string;
-      _type: 'reference';
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: 'treatment';
-    };
-    externalLink?: string;
-    referencedTreatments?: Array<{
-      _ref: string;
-      _type: 'reference';
-      _weak?: boolean;
-      _key: string;
-      [internalGroqTypeReferenceTo]?: 'treatment';
-    }>;
-    _type: 'navMenuItem';
     _key: string;
   }>;
 };
@@ -330,8 +337,8 @@ export type SanityAssetSourceData = {
 };
 
 export type AllSanitySchemaTypes =
-  | CustomPage
   | Navigation
+  | CustomPage
   | Treatment
   | TreatmentCategory
   | HomePage
@@ -464,7 +471,7 @@ export type CUSTOM_PAGE_QUERYResult = {
   }> | null;
 } | null;
 // Variable: NAVIGATION_QUERY
-// Query: *[_type == 'navigation'][0]{  navMenuItems[]{    _id,    label,    mode,    mode == 'link' && linkType == "external" => {      "link": {        "type": "external",        "url": externalLink      }    },    mode == "link" && linkType == "internal" => {      "link": {        "type": "internal",        "target": internalLink->{          name,          shortDescription,          "slug": slug.current,          "pageType": _type,          mainImage        }      }    },    mode == "group" => {      "group": referencedTreatments[]->{        name,        shortDescription,        "slug": slug.current,        mainImage      }    }  }}
+// Query: *[_type == 'navigation'][0]{  navMenuItems[]{    _id,    label,    mode,    mode == 'link' && linkType == "external" => {      "link": {        "type": "external",        "url": externalLink      }    },    mode == "link" && linkType == "internal" => {      "link": {        "type": "internal",        "target": internalLink->{          name,          shortDescription,          "slug": slug.current,          "pageType": _type,          mainImage        }      }    },    mode == "group" => {      "group": referencedTreatments[]->{        name,        shortDescription,        "slug": slug.current,        "pageType": _type,        mainImage      }    }  }}
 export type NAVIGATION_QUERYResult = {
   navMenuItems: Array<
     | {
@@ -473,30 +480,40 @@ export type NAVIGATION_QUERYResult = {
         mode: 'group' | 'link' | null;
         link: {
           type: 'internal';
-          target: {
-            name: string | null;
-            shortDescription: string | null;
-            slug: string | null;
-            pageType: 'treatment';
-            mainImage: {
-              asset?: {
-                _ref: string;
-                _type: 'reference';
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              alt?: string;
-              _type: 'image';
-            } | null;
-          } | null;
+          target:
+            | {
+                name: null;
+                shortDescription: null;
+                slug: string | null;
+                pageType: 'customPage';
+                mainImage: null;
+              }
+            | {
+                name: string | null;
+                shortDescription: string | null;
+                slug: string | null;
+                pageType: 'treatment';
+                mainImage: {
+                  asset?: {
+                    _ref: string;
+                    _type: 'reference';
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+                  };
+                  media?: unknown;
+                  hotspot?: SanityImageHotspot;
+                  crop?: SanityImageCrop;
+                  alt?: string;
+                  _type: 'image';
+                } | null;
+              }
+            | null;
         };
         group: Array<{
           name: string | null;
           shortDescription: string | null;
           slug: string | null;
+          pageType: 'treatment';
           mainImage: {
             asset?: {
               _ref: string;
@@ -524,6 +541,7 @@ export type NAVIGATION_QUERYResult = {
           name: string | null;
           shortDescription: string | null;
           slug: string | null;
+          pageType: 'treatment';
           mainImage: {
             asset?: {
               _ref: string;
@@ -547,6 +565,7 @@ export type NAVIGATION_QUERYResult = {
           name: string | null;
           shortDescription: string | null;
           slug: string | null;
+          pageType: 'treatment';
           mainImage: {
             asset?: {
               _ref: string;
@@ -568,25 +587,34 @@ export type NAVIGATION_QUERYResult = {
         mode: 'group' | 'link' | null;
         link: {
           type: 'internal';
-          target: {
-            name: string | null;
-            shortDescription: string | null;
-            slug: string | null;
-            pageType: 'treatment';
-            mainImage: {
-              asset?: {
-                _ref: string;
-                _type: 'reference';
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              alt?: string;
-              _type: 'image';
-            } | null;
-          } | null;
+          target:
+            | {
+                name: null;
+                shortDescription: null;
+                slug: string | null;
+                pageType: 'customPage';
+                mainImage: null;
+              }
+            | {
+                name: string | null;
+                shortDescription: string | null;
+                slug: string | null;
+                pageType: 'treatment';
+                mainImage: {
+                  asset?: {
+                    _ref: string;
+                    _type: 'reference';
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+                  };
+                  media?: unknown;
+                  hotspot?: SanityImageHotspot;
+                  crop?: SanityImageCrop;
+                  alt?: string;
+                  _type: 'image';
+                } | null;
+              }
+            | null;
         };
       }
     | {
@@ -614,6 +642,6 @@ declare module '@sanity/client' {
     '*[\n  _type == \'treatment\'\n]{\n  "id":_id,\n  name,\n  "slug":slug.current,\n  shortDescription,\n  bookingUrl,\n  mainImage\n}': TREATMENTS_QUERYResult;
     '*[\n  _type == \'treatment\' &&\n  slug.current == $slug\n][0]{\n  "id":_id,\n  name,\n  shortDescription,\n  bookingUrl,\n  details\n}': SINGLE_TREATMENT_QUERYResult;
     "*[_type == 'customPage' && slug.current == $slug][0]{\n  title,\n  content\n}": CUSTOM_PAGE_QUERYResult;
-    '*[_type == \'navigation\'][0]{\n  navMenuItems[]{\n    _id,\n    label,\n    mode,\n    mode == \'link\' && linkType == "external" => {\n      "link": {\n        "type": "external",\n        "url": externalLink\n      }\n    },\n    mode == "link" && linkType == "internal" => {\n      "link": {\n        "type": "internal",\n        "target": internalLink->{\n          name,\n          shortDescription,\n          "slug": slug.current,\n          "pageType": _type,\n          mainImage\n        }\n      }\n    },\n    mode == "group" => {\n      "group": referencedTreatments[]->{\n        name,\n        shortDescription,\n        "slug": slug.current,\n        mainImage\n      }\n    }\n  }\n}': NAVIGATION_QUERYResult;
+    '*[_type == \'navigation\'][0]{\n  navMenuItems[]{\n    _id,\n    label,\n    mode,\n    mode == \'link\' && linkType == "external" => {\n      "link": {\n        "type": "external",\n        "url": externalLink\n      }\n    },\n    mode == "link" && linkType == "internal" => {\n      "link": {\n        "type": "internal",\n        "target": internalLink->{\n          name,\n          shortDescription,\n          "slug": slug.current,\n          "pageType": _type,\n          mainImage\n        }\n      }\n    },\n    mode == "group" => {\n      "group": referencedTreatments[]->{\n        name,\n        shortDescription,\n        "slug": slug.current,\n        "pageType": _type,\n        mainImage\n      }\n    }\n  }\n}': NAVIGATION_QUERYResult;
   }
 }

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -22,7 +22,7 @@ export type Navigation = {
   navMenuItems?: Array<{
     label?: string;
     mode?: 'link' | 'group';
-    linkType?: 'internal' | 'external';
+    linkType?: 'internal' | 'external' | 'static';
     internalLink?:
       | {
           _ref: string;
@@ -37,6 +37,7 @@ export type Navigation = {
           [internalGroqTypeReferenceTo]?: 'customPage';
         };
     externalLink?: string;
+    staticPath?: string;
     referencedTreatments?: Array<{
       _ref: string;
       _type: 'reference';
@@ -471,9 +472,37 @@ export type CUSTOM_PAGE_QUERYResult = {
   }> | null;
 } | null;
 // Variable: NAVIGATION_QUERY
-// Query: *[_type == 'navigation'][0]{  navMenuItems[]{    _id,    label,    mode,    mode == 'link' && linkType == "external" => {      "link": {        "type": "external",        "url": externalLink      }    },    mode == "link" && linkType == "internal" => {      "link": {        "type": "internal",        "target": internalLink->{          name,          shortDescription,          "slug": slug.current,          "pageType": _type,          mainImage        }      }    },    mode == "group" => {      "group": referencedTreatments[]->{        name,        shortDescription,        "slug": slug.current,        "pageType": _type,        mainImage      }    }  }}
+// Query: *[_type == 'navigation'][0]{  navMenuItems[]{    _id,    label,    mode,    mode == 'link' && linkType == "external" => {      "link": {        "type": "external",        "url": externalLink      }    },    mode == "link" && linkType == "static" => {      "link": {        "type": "static",        "path": staticPath      }    },    mode == "link" && linkType == "internal" => {      "link": {        "type": "internal",        "target": internalLink->{          name,          shortDescription,          "slug": slug.current,          "pageType": _type,          mainImage        }      }    },    mode == "group" => {      "group": referencedTreatments[]->{        name,        shortDescription,        "slug": slug.current,        "pageType": _type,        mainImage      }    }  }}
 export type NAVIGATION_QUERYResult = {
   navMenuItems: Array<
+    | {
+        _id: null;
+        label: string | null;
+        mode: 'group' | 'link' | null;
+        link: {
+          type: 'static';
+          path: string | null;
+        };
+        group: Array<{
+          name: string | null;
+          shortDescription: string | null;
+          slug: string | null;
+          pageType: 'treatment';
+          mainImage: {
+            asset?: {
+              _ref: string;
+              _type: 'reference';
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            alt?: string;
+            _type: 'image';
+          } | null;
+        }> | null;
+      }
     | {
         _id: null;
         label: string | null;
@@ -580,6 +609,15 @@ export type NAVIGATION_QUERYResult = {
             _type: 'image';
           } | null;
         }> | null;
+      }
+    | {
+        _id: null;
+        label: string | null;
+        mode: 'group' | 'link' | null;
+        link: {
+          type: 'static';
+          path: string | null;
+        };
       }
     | {
         _id: null;
@@ -642,6 +680,6 @@ declare module '@sanity/client' {
     '*[\n  _type == \'treatment\'\n]{\n  "id":_id,\n  name,\n  "slug":slug.current,\n  shortDescription,\n  bookingUrl,\n  mainImage\n}': TREATMENTS_QUERYResult;
     '*[\n  _type == \'treatment\' &&\n  slug.current == $slug\n][0]{\n  "id":_id,\n  name,\n  shortDescription,\n  bookingUrl,\n  details\n}': SINGLE_TREATMENT_QUERYResult;
     "*[_type == 'customPage' && slug.current == $slug][0]{\n  title,\n  content\n}": CUSTOM_PAGE_QUERYResult;
-    '*[_type == \'navigation\'][0]{\n  navMenuItems[]{\n    _id,\n    label,\n    mode,\n    mode == \'link\' && linkType == "external" => {\n      "link": {\n        "type": "external",\n        "url": externalLink\n      }\n    },\n    mode == "link" && linkType == "internal" => {\n      "link": {\n        "type": "internal",\n        "target": internalLink->{\n          name,\n          shortDescription,\n          "slug": slug.current,\n          "pageType": _type,\n          mainImage\n        }\n      }\n    },\n    mode == "group" => {\n      "group": referencedTreatments[]->{\n        name,\n        shortDescription,\n        "slug": slug.current,\n        "pageType": _type,\n        mainImage\n      }\n    }\n  }\n}': NAVIGATION_QUERYResult;
+    '*[_type == \'navigation\'][0]{\n  navMenuItems[]{\n    _id,\n    label,\n    mode,\n    mode == \'link\' && linkType == "external" => {\n      "link": {\n        "type": "external",\n        "url": externalLink\n      }\n    },\n    mode == "link" && linkType == "static" => {\n      "link": {\n        "type": "static",\n        "path": staticPath\n      }\n    },\n    mode == "link" && linkType == "internal" => {\n      "link": {\n        "type": "internal",\n        "target": internalLink->{\n          name,\n          shortDescription,\n          "slug": slug.current,\n          "pageType": _type,\n          mainImage\n        }\n      }\n    },\n    mode == "group" => {\n      "group": referencedTreatments[]->{\n        name,\n        shortDescription,\n        "slug": slug.current,\n        "pageType": _type,\n        mainImage\n      }\n    }\n  }\n}': NAVIGATION_QUERYResult;
   }
 }

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -13,42 +13,6 @@
  */
 
 // Source: schema.json
-export type Navigation = {
-  _id: string;
-  _type: 'navigation';
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  navMenuItems?: Array<{
-    label?: string;
-    mode?: 'link' | 'group';
-    linkType?: 'internal' | 'external';
-    internalLink?:
-      | {
-          _ref: string;
-          _type: 'reference';
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: 'treatment';
-        }
-      | {
-          _ref: string;
-          _type: 'reference';
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: 'customPage';
-        };
-    externalLink?: string;
-    referencedTreatments?: Array<{
-      _ref: string;
-      _type: 'reference';
-      _weak?: boolean;
-      _key: string;
-      [internalGroqTypeReferenceTo]?: 'treatment';
-    }>;
-    _type: 'navMenuItem';
-    _key: string;
-  }>;
-};
-
 export type CustomPage = {
   _id: string;
   _type: 'customPage';
@@ -77,6 +41,35 @@ export type CustomPage = {
   }>;
 };
 
+export type Navigation = {
+  _id: string;
+  _type: 'navigation';
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  navMenuItems?: Array<{
+    label?: string;
+    mode?: 'link' | 'group';
+    linkType?: 'internal' | 'external';
+    internalLink?: {
+      _ref: string;
+      _type: 'reference';
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: 'treatment';
+    };
+    externalLink?: string;
+    referencedTreatments?: Array<{
+      _ref: string;
+      _type: 'reference';
+      _weak?: boolean;
+      _key: string;
+      [internalGroqTypeReferenceTo]?: 'treatment';
+    }>;
+    _type: 'navMenuItem';
+    _key: string;
+  }>;
+};
+
 export type Treatment = {
   _id: string;
   _type: 'treatment';
@@ -100,6 +93,12 @@ export type Treatment = {
     _type: 'image';
   };
   bookingUrl?: string;
+  category?: {
+    _ref: string;
+    _type: 'reference';
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: 'treatmentCategory';
+  };
   details?: Array<
     | {
         children?: Array<{
@@ -141,6 +140,16 @@ export type Treatment = {
         _key: string;
       }
   >;
+};
+
+export type TreatmentCategory = {
+  _id: string;
+  _type: 'treatmentCategory';
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name?: string;
+  slug?: Slug;
 };
 
 export type HomePage = {
@@ -321,9 +330,10 @@ export type SanityAssetSourceData = {
 };
 
 export type AllSanitySchemaTypes =
-  | Navigation
   | CustomPage
+  | Navigation
   | Treatment
+  | TreatmentCategory
   | HomePage
   | BlockContent
   | SanityImagePaletteSwatch
@@ -463,34 +473,25 @@ export type NAVIGATION_QUERYResult = {
         mode: 'group' | 'link' | null;
         link: {
           type: 'internal';
-          target:
-            | {
-                name: null;
-                shortDescription: null;
-                slug: string | null;
-                pageType: 'customPage';
-                mainImage: null;
-              }
-            | {
-                name: string | null;
-                shortDescription: string | null;
-                slug: string | null;
-                pageType: 'treatment';
-                mainImage: {
-                  asset?: {
-                    _ref: string;
-                    _type: 'reference';
-                    _weak?: boolean;
-                    [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-                  };
-                  media?: unknown;
-                  hotspot?: SanityImageHotspot;
-                  crop?: SanityImageCrop;
-                  alt?: string;
-                  _type: 'image';
-                } | null;
-              }
-            | null;
+          target: {
+            name: string | null;
+            shortDescription: string | null;
+            slug: string | null;
+            pageType: 'treatment';
+            mainImage: {
+              asset?: {
+                _ref: string;
+                _type: 'reference';
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              alt?: string;
+              _type: 'image';
+            } | null;
+          } | null;
         };
         group: Array<{
           name: string | null;
@@ -567,34 +568,25 @@ export type NAVIGATION_QUERYResult = {
         mode: 'group' | 'link' | null;
         link: {
           type: 'internal';
-          target:
-            | {
-                name: null;
-                shortDescription: null;
-                slug: string | null;
-                pageType: 'customPage';
-                mainImage: null;
-              }
-            | {
-                name: string | null;
-                shortDescription: string | null;
-                slug: string | null;
-                pageType: 'treatment';
-                mainImage: {
-                  asset?: {
-                    _ref: string;
-                    _type: 'reference';
-                    _weak?: boolean;
-                    [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-                  };
-                  media?: unknown;
-                  hotspot?: SanityImageHotspot;
-                  crop?: SanityImageCrop;
-                  alt?: string;
-                  _type: 'image';
-                } | null;
-              }
-            | null;
+          target: {
+            name: string | null;
+            shortDescription: string | null;
+            slug: string | null;
+            pageType: 'treatment';
+            mainImage: {
+              asset?: {
+                _ref: string;
+                _type: 'reference';
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              alt?: string;
+              _type: 'image';
+            } | null;
+          } | null;
         };
       }
     | {

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -23,12 +23,19 @@ export type Navigation = {
     label?: string;
     mode?: 'link' | 'group';
     linkType?: 'internal' | 'external';
-    internalLink?: {
-      _ref: string;
-      _type: 'reference';
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: 'treatment';
-    };
+    internalLink?:
+      | {
+          _ref: string;
+          _type: 'reference';
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: 'treatment';
+        }
+      | {
+          _ref: string;
+          _type: 'reference';
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: 'customPage';
+        };
     externalLink?: string;
     referencedTreatments?: Array<{
       _ref: string;
@@ -38,6 +45,34 @@ export type Navigation = {
       [internalGroqTypeReferenceTo]?: 'treatment';
     }>;
     _type: 'navMenuItem';
+    _key: string;
+  }>;
+};
+
+export type CustomPage = {
+  _id: string;
+  _type: 'customPage';
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
+  slug?: Slug;
+  content?: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: 'span';
+      _key: string;
+    }>;
+    style?: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote';
+    listItem?: 'bullet' | 'number';
+    markDefs?: Array<{
+      href?: string;
+      _type: 'link';
+      _key: string;
+    }>;
+    level?: number;
+    _type: 'block';
     _key: string;
   }>;
 };
@@ -287,6 +322,7 @@ export type SanityAssetSourceData = {
 
 export type AllSanitySchemaTypes =
   | Navigation
+  | CustomPage
   | Treatment
   | HomePage
   | BlockContent
@@ -394,8 +430,31 @@ export type SINGLE_TREATMENT_QUERYResult = {
       }
   > | null;
 } | null;
+// Variable: CUSTOM_PAGE_QUERY
+// Query: *[_type == 'customPage' && slug.current == $slug][0]{  title,  content}
+export type CUSTOM_PAGE_QUERYResult = {
+  title: string | null;
+  content: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: 'span';
+      _key: string;
+    }>;
+    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal';
+    listItem?: 'bullet' | 'number';
+    markDefs?: Array<{
+      href?: string;
+      _type: 'link';
+      _key: string;
+    }>;
+    level?: number;
+    _type: 'block';
+    _key: string;
+  }> | null;
+} | null;
 // Variable: NAVIGATION_QUERY
-// Query: *[_type == 'navigation'][0]{  navMenuItems[]{    _id,    label,    mode,    mode == 'link' && linkType == "external" => {      "link": {        "type": "external",        "url": externalLink      }    },    mode == "link" && linkType == "internal" => {      "link": {        "type": "internal",        "target": internalLink->{          name,          shortDescription,          "slug": slug.current,          mainImage        }      }    },    mode == "group" => {      "group": referencedTreatments[]->{        name,        shortDescription,        "slug": slug.current,        mainImage      }    }  }}
+// Query: *[_type == 'navigation'][0]{  navMenuItems[]{    _id,    label,    mode,    mode == 'link' && linkType == "external" => {      "link": {        "type": "external",        "url": externalLink      }    },    mode == "link" && linkType == "internal" => {      "link": {        "type": "internal",        "target": internalLink->{          name,          shortDescription,          "slug": slug.current,          "pageType": _type,          mainImage        }      }    },    mode == "group" => {      "group": referencedTreatments[]->{        name,        shortDescription,        "slug": slug.current,        mainImage      }    }  }}
 export type NAVIGATION_QUERYResult = {
   navMenuItems: Array<
     | {
@@ -404,24 +463,34 @@ export type NAVIGATION_QUERYResult = {
         mode: 'group' | 'link' | null;
         link: {
           type: 'internal';
-          target: {
-            name: string | null;
-            shortDescription: string | null;
-            slug: string | null;
-            mainImage: {
-              asset?: {
-                _ref: string;
-                _type: 'reference';
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              alt?: string;
-              _type: 'image';
-            } | null;
-          } | null;
+          target:
+            | {
+                name: null;
+                shortDescription: null;
+                slug: string | null;
+                pageType: 'customPage';
+                mainImage: null;
+              }
+            | {
+                name: string | null;
+                shortDescription: string | null;
+                slug: string | null;
+                pageType: 'treatment';
+                mainImage: {
+                  asset?: {
+                    _ref: string;
+                    _type: 'reference';
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+                  };
+                  media?: unknown;
+                  hotspot?: SanityImageHotspot;
+                  crop?: SanityImageCrop;
+                  alt?: string;
+                  _type: 'image';
+                } | null;
+              }
+            | null;
         };
         group: Array<{
           name: string | null;
@@ -498,24 +567,34 @@ export type NAVIGATION_QUERYResult = {
         mode: 'group' | 'link' | null;
         link: {
           type: 'internal';
-          target: {
-            name: string | null;
-            shortDescription: string | null;
-            slug: string | null;
-            mainImage: {
-              asset?: {
-                _ref: string;
-                _type: 'reference';
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              alt?: string;
-              _type: 'image';
-            } | null;
-          } | null;
+          target:
+            | {
+                name: null;
+                shortDescription: null;
+                slug: string | null;
+                pageType: 'customPage';
+                mainImage: null;
+              }
+            | {
+                name: string | null;
+                shortDescription: string | null;
+                slug: string | null;
+                pageType: 'treatment';
+                mainImage: {
+                  asset?: {
+                    _ref: string;
+                    _type: 'reference';
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+                  };
+                  media?: unknown;
+                  hotspot?: SanityImageHotspot;
+                  crop?: SanityImageCrop;
+                  alt?: string;
+                  _type: 'image';
+                } | null;
+              }
+            | null;
         };
       }
     | {
@@ -542,6 +621,7 @@ declare module '@sanity/client' {
     "*[_type == 'homePage'][0]{\n  headline,\n  subheading,\n  image,\n  ctaLabel,\n}": HOME_PAGE_QUERYResult;
     '*[\n  _type == \'treatment\'\n]{\n  "id":_id,\n  name,\n  "slug":slug.current,\n  shortDescription,\n  bookingUrl,\n  mainImage\n}': TREATMENTS_QUERYResult;
     '*[\n  _type == \'treatment\' &&\n  slug.current == $slug\n][0]{\n  "id":_id,\n  name,\n  shortDescription,\n  bookingUrl,\n  details\n}': SINGLE_TREATMENT_QUERYResult;
-    '*[_type == \'navigation\'][0]{\n  navMenuItems[]{\n    _id,\n    label,\n    mode,\n    mode == \'link\' && linkType == "external" => {\n      "link": {\n        "type": "external",\n        "url": externalLink\n      }\n    },\n    mode == "link" && linkType == "internal" => {\n      "link": {\n        "type": "internal",\n        "target": internalLink->{\n          name,\n          shortDescription,\n          "slug": slug.current,\n          mainImage\n        }\n      }\n    },\n    mode == "group" => {\n      "group": referencedTreatments[]->{\n        name,\n        shortDescription,\n        "slug": slug.current,\n        mainImage\n      }\n    }\n  }\n}': NAVIGATION_QUERYResult;
+    "*[_type == 'customPage' && slug.current == $slug][0]{\n  title,\n  content\n}": CUSTOM_PAGE_QUERYResult;
+    '*[_type == \'navigation\'][0]{\n  navMenuItems[]{\n    _id,\n    label,\n    mode,\n    mode == \'link\' && linkType == "external" => {\n      "link": {\n        "type": "external",\n        "url": externalLink\n      }\n    },\n    mode == "link" && linkType == "internal" => {\n      "link": {\n        "type": "internal",\n        "target": internalLink->{\n          name,\n          shortDescription,\n          "slug": slug.current,\n          "pageType": _type,\n          mainImage\n        }\n      }\n    },\n    mode == "group" => {\n      "group": referencedTreatments[]->{\n        name,\n        shortDescription,\n        "slug": slug.current,\n        mainImage\n      }\n    }\n  }\n}': NAVIGATION_QUERYResult;
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -1,225 +1,5 @@
 [
   {
-    "name": "navigation",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "navigation"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "navMenuItems": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "object",
-            "attributes": {
-              "label": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
-              "mode": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "union",
-                  "of": [
-                    {
-                      "type": "string",
-                      "value": "link"
-                    },
-                    {
-                      "type": "string",
-                      "value": "group"
-                    }
-                  ]
-                },
-                "optional": true
-              },
-              "linkType": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "union",
-                  "of": [
-                    {
-                      "type": "string",
-                      "value": "internal"
-                    },
-                    {
-                      "type": "string",
-                      "value": "external"
-                    }
-                  ]
-                },
-                "optional": true
-              },
-              "internalLink": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "union",
-                  "of": [
-                    {
-                      "type": "object",
-                      "attributes": {
-                        "_ref": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "reference"
-                          }
-                        },
-                        "_weak": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "boolean"
-                          },
-                          "optional": true
-                        }
-                      },
-                      "dereferencesTo": "treatment"
-                    },
-                    {
-                      "type": "object",
-                      "attributes": {
-                        "_ref": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "reference"
-                          }
-                        },
-                        "_weak": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "boolean"
-                          },
-                          "optional": true
-                        }
-                      },
-                      "dereferencesTo": "customPage"
-                    }
-                  ]
-                },
-                "optional": true
-              },
-              "externalLink": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
-              "referencedTreatments": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "array",
-                  "of": {
-                    "type": "object",
-                    "attributes": {
-                      "_ref": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string"
-                        }
-                      },
-                      "_type": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string",
-                          "value": "reference"
-                        }
-                      },
-                      "_weak": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "boolean"
-                        },
-                        "optional": true
-                      }
-                    },
-                    "dereferencesTo": "treatment",
-                    "rest": {
-                      "type": "object",
-                      "attributes": {
-                        "_key": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "optional": true
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "navMenuItem"
-                }
-              }
-            },
-            "rest": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optional": true
-      }
-    }
-  },
-  {
     "name": "customPage",
     "type": "document",
     "attributes": {
@@ -451,6 +231,195 @@
     }
   },
   {
+    "name": "navigation",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "navigation"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "navMenuItems": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "label": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "mode": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "link"
+                    },
+                    {
+                      "type": "string",
+                      "value": "group"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "linkType": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "internal"
+                    },
+                    {
+                      "type": "string",
+                      "value": "external"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "internalLink": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "treatment"
+                },
+                "optional": true
+              },
+              "externalLink": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "referencedTreatments": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "_ref": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "reference"
+                        }
+                      },
+                      "_weak": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "boolean"
+                        },
+                        "optional": true
+                      }
+                    },
+                    "dereferencesTo": "treatment",
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "navMenuItem"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "treatment",
     "type": "document",
     "attributes": {
@@ -587,6 +556,36 @@
         "type": "objectAttribute",
         "value": {
           "type": "string"
+        },
+        "optional": true
+      },
+      "category": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "_ref": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              }
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "reference"
+              }
+            },
+            "_weak": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "boolean"
+              },
+              "optional": true
+            }
+          },
+          "dereferencesTo": "treatmentCategory"
         },
         "optional": true
       },
@@ -847,6 +846,58 @@
               }
             ]
           }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "treatmentCategory",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "treatmentCategory"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
         },
         "optional": true
       }

--- a/schema.json
+++ b/schema.json
@@ -85,30 +85,61 @@
               "internalLink": {
                 "type": "objectAttribute",
                 "value": {
-                  "type": "object",
-                  "attributes": {
-                    "_ref": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "_type": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string",
-                        "value": "reference"
-                      }
-                    },
-                    "_weak": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "boolean"
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
                       },
-                      "optional": true
+                      "dereferencesTo": "treatment"
+                    },
+                    {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
+                      },
+                      "dereferencesTo": "customPage"
                     }
-                  },
-                  "dereferencesTo": "treatment"
+                  ]
                 },
                 "optional": true
               },
@@ -168,6 +199,237 @@
                 "value": {
                   "type": "string",
                   "value": "navMenuItem"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "customPage",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "customPage"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      },
+      "content": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "children": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "marks": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "array",
+                          "of": {
+                            "type": "string"
+                          }
+                        },
+                        "optional": true
+                      },
+                      "text": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "span"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "style": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "normal"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h1"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h2"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h3"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h4"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h5"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h6"
+                    },
+                    {
+                      "type": "string",
+                      "value": "blockquote"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "listItem": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "bullet"
+                    },
+                    {
+                      "type": "string",
+                      "value": "number"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "markDefs": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "href": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "link"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "level": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "number"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "block"
                 }
               }
             },

--- a/schema.json
+++ b/schema.json
@@ -77,6 +77,10 @@
                     {
                       "type": "string",
                       "value": "external"
+                    },
+                    {
+                      "type": "string",
+                      "value": "static"
                     }
                   ]
                 },
@@ -144,6 +148,13 @@
                 "optional": true
               },
               "externalLink": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "staticPath": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,225 @@
 [
   {
+    "name": "navigation",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "navigation"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "navMenuItems": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "label": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "mode": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "link"
+                    },
+                    {
+                      "type": "string",
+                      "value": "group"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "linkType": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "internal"
+                    },
+                    {
+                      "type": "string",
+                      "value": "external"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "internalLink": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
+                      },
+                      "dereferencesTo": "treatment"
+                    },
+                    {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
+                      },
+                      "dereferencesTo": "customPage"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "externalLink": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "referencedTreatments": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "_ref": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "reference"
+                        }
+                      },
+                      "_weak": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "boolean"
+                        },
+                        "optional": true
+                      }
+                    },
+                    "dereferencesTo": "treatment",
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "navMenuItem"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "customPage",
     "type": "document",
     "attributes": {
@@ -210,195 +430,6 @@
                 "value": {
                   "type": "string",
                   "value": "block"
-                }
-              }
-            },
-            "rest": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "navigation",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "navigation"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "navMenuItems": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "object",
-            "attributes": {
-              "label": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
-              "mode": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "union",
-                  "of": [
-                    {
-                      "type": "string",
-                      "value": "link"
-                    },
-                    {
-                      "type": "string",
-                      "value": "group"
-                    }
-                  ]
-                },
-                "optional": true
-              },
-              "linkType": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "union",
-                  "of": [
-                    {
-                      "type": "string",
-                      "value": "internal"
-                    },
-                    {
-                      "type": "string",
-                      "value": "external"
-                    }
-                  ]
-                },
-                "optional": true
-              },
-              "internalLink": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "object",
-                  "attributes": {
-                    "_ref": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "_type": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string",
-                        "value": "reference"
-                      }
-                    },
-                    "_weak": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "boolean"
-                      },
-                      "optional": true
-                    }
-                  },
-                  "dereferencesTo": "treatment"
-                },
-                "optional": true
-              },
-              "externalLink": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
-              "referencedTreatments": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "array",
-                  "of": {
-                    "type": "object",
-                    "attributes": {
-                      "_ref": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string"
-                        }
-                      },
-                      "_type": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string",
-                          "value": "reference"
-                        }
-                      },
-                      "_weak": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "boolean"
-                        },
-                        "optional": true
-                      }
-                    },
-                    "dereferencesTo": "treatment",
-                    "rest": {
-                      "type": "object",
-                      "attributes": {
-                        "_key": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "optional": true
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "navMenuItem"
                 }
               }
             },

--- a/src/app/arlista/page.tsx
+++ b/src/app/arlista/page.tsx
@@ -1,0 +1,7 @@
+export default function PriceListPage() {
+  return (
+    <>
+      <h1>Árlista</h1>
+    </>
+  );
+}

--- a/src/app/components/DesktopNavigation.tsx
+++ b/src/app/components/DesktopNavigation.tsx
@@ -33,6 +33,15 @@ type ExternalLink = {
   };
 };
 
+type StaticLink = {
+  label: string;
+  mode: 'link';
+  link: {
+    type: 'static';
+    path: string;
+  };
+};
+
 type InternalLink = {
   label: string;
   mode: 'link';
@@ -48,7 +57,7 @@ type Collection = {
   group: NavTarget[];
 };
 
-export type NavMenuItemFromSanity = ExternalLink | InternalLink | Collection;
+export type NavMenuItemFromSanity = ExternalLink | StaticLink | InternalLink | Collection;
 
 type DesktopNavigationProps = {
   navMenuItems: NavMenuItemFromSanity[];
@@ -76,6 +85,17 @@ export const DesktopNavigation = ({ navMenuItems }: DesktopNavigationProps) => {
                         >
                           {menuItem.label}
                         </a>
+                      </NavigationMenuLink>
+                    </NavigationMenuItem>
+                  )}
+                {menuItem.mode === 'link' &&
+                  menuItem.link.type === 'static' && (
+                    <NavigationMenuItem>
+                      <NavigationMenuLink
+                        asChild
+                        className={navigationMenuTriggerStyle()}
+                      >
+                        <Link href={menuItem.link.path}>{menuItem.label}</Link>
                       </NavigationMenuLink>
                     </NavigationMenuItem>
                   )}

--- a/src/app/components/DesktopNavigation.tsx
+++ b/src/app/components/DesktopNavigation.tsx
@@ -91,12 +91,12 @@ export const DesktopNavigation = ({ navMenuItems }: DesktopNavigationProps) => {
                     <NavigationMenuContent>
                       <ul className="grid w-96 flex-col gap-2">
                         {menuItem.group.map(
-                          ({ name, slug, shortDescription, mainImage }) => (
+                          ({ name, slug, pageType, shortDescription, mainImage }) => (
                             <ListItem
                               key={slug}
                               title={name}
                               image={mainImage}
-                              href={`/kezelesek/${slug}`}
+                              href={pageType === 'customPage' ? `/p/${slug}` : `/kezelesek/${slug}`}
                             >
                               {shortDescription}
                             </ListItem>

--- a/src/app/components/DesktopNavigation.tsx
+++ b/src/app/components/DesktopNavigation.tsx
@@ -16,9 +16,10 @@ import { urlFor } from '@/sanity/lib/image';
 // eslint-disable-next-line no-restricted-imports
 import { SanityImageAsset } from '../../../sanity.types';
 
-type TreatmentInNav = {
+type NavTarget = {
   name: string;
   slug: string;
+  pageType: 'treatment' | 'customPage';
   mainImage: SanityImageAsset;
   shortDescription: string;
 };
@@ -37,14 +38,14 @@ type InternalLink = {
   mode: 'link';
   link: {
     type: 'internal';
-    target: TreatmentInNav;
+    target: NavTarget;
   };
 };
 
 type Collection = {
   mode: 'group';
   label: string;
-  group: TreatmentInNav[];
+  group: NavTarget[];
 };
 
 export type NavMenuItemFromSanity = ExternalLink | InternalLink | Collection;
@@ -80,16 +81,7 @@ export const DesktopNavigation = ({ navMenuItems }: DesktopNavigationProps) => {
                   )}
                 {menuItem.mode === 'link' &&
                   menuItem.link.type === 'internal' && (
-                    <NavigationMenuItem>
-                      <NavigationMenuLink
-                        asChild
-                        className={navigationMenuTriggerStyle()}
-                      >
-                        <Link href={`/kezelesek/${menuItem.link.target.slug}`}>
-                          {menuItem.label}
-                        </Link>
-                      </NavigationMenuLink>
-                    </NavigationMenuItem>
+                    <InternalLinkComponent menuItem={menuItem as InternalLink} />
                   )}
                 {menuItem.mode === 'group' && (
                   <NavigationMenuItem>
@@ -158,5 +150,22 @@ function ListItem({
         </Link>
       </NavigationMenuLink>
     </li>
+  );
+}
+
+type InternalLinkComponentProps = {
+  menuItem: InternalLink;
+};
+
+function InternalLinkComponent({ menuItem }: InternalLinkComponentProps) {
+  const { slug, pageType } = menuItem.link.target;
+  const href = pageType === 'customPage' ? `/p/${slug}` : `/kezelesek/${slug}`;
+
+  return (
+    <NavigationMenuItem>
+      <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+        <Link href={href}>{menuItem.label}</Link>
+      </NavigationMenuLink>
+    </NavigationMenuItem>
   );
 }

--- a/src/app/p/[slug]/page.tsx
+++ b/src/app/p/[slug]/page.tsx
@@ -1,0 +1,72 @@
+import { notFound } from 'next/navigation';
+import { PortableText } from 'next-sanity';
+
+import { BackgroundShapes } from '@/app/components/BackgroundShapes';
+import { Container } from '@/app/components/Container';
+import { Footer } from '@/app/components/Footer';
+import { components } from '@/app/components/PortableTextComponents';
+import { fetchCustomPageBySlug } from '@/sanity/lib/queries';
+
+export default async function CustomPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const { data: pageData } = await fetchCustomPageBySlug(slug);
+
+  if (pageData?.content == null || pageData?.title == null) {
+    notFound();
+  }
+
+  const { title, content } = pageData;
+
+  return (
+    <>
+      {/* <Header navigation={navigation} /> */}
+      <main className="flex flex-1 flex-col px-4 pt-20 lg:px-0 lg:pt-0">
+        <Container className="flex flex-1 flex-col py-6 lg:py-12">
+          <BackgroundShapes />
+          <div className="mx-auto flex w-full max-w-5xl">
+            <div className="flex flex-col gap-6 lg:gap-10">
+              <h1 className="text-fuego-900 font-serif text-3xl font-bold lg:text-5xl">
+                {title}
+              </h1>
+              <div className="prose lg:prose-lg">
+                <PortableText value={content} components={components} />
+              </div>
+              {/* <Link
+                href="/"
+                className="text-fuego-600 hover:bg-fuego-200/75 flex items-center gap-2 rounded-md p-2 font-semibold md:self-start"
+              >
+                <ArrowLeftIcon className="h-6 w-6" />
+                <span>Vissza</span>
+              </Link>
+              <h1 className="text-fuego-900 font-serif text-3xl font-bold lg:text-5xl">
+                {name}
+              </h1>
+              <div className="text-fuego-900 bg-fuego-100 border-fuego-300 flex max-w-2xl flex-col gap-6 rounded-md border p-4 lg:text-lg">
+                <p>{shortDescription}</p>
+                <Link
+                  href={bookingUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:bg-fuego-400 group bg-fuego-300 flex items-center justify-center gap-2 rounded-md px-4 py-2 font-semibold transition-colors hover:drop-shadow-sm md:self-start"
+                >
+                  <CalendarHeartIcon className="text-fuego-800/75" />
+                  <span>Foglalás</span>
+                  <ArrowRightIcon className="-rotate-45 transition-transform group-hover:-rotate-45 group-focus:-rotate-45 group-active:translate-x-0.5 lg:rotate-0" />
+                </Link>
+              </div>
+              <div className="prose lg:prose-lg">
+                <PortableText value={details} components={components} />
+              </div> */}
+            </div>
+          </div>
+        </Container>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,7 +77,7 @@ export default async function Home() {
                     Green Point Beauty
                   </strong>
                   <span className="text-fuego-900/75">
-                    📍 1066 Budapest, Zichy Jenő u. 1. Fsz. 2.
+                    📍 1066 Budapest, Zichy Jenő u. 1. Fsz. 2. (kapucsengő: 101)
                   </span>
                   <a
                     className="text-fuego-900/75 underline underline-offset-4"
@@ -86,7 +86,7 @@ export default async function Home() {
                     📞 +36 30 420 0933
                   </a>
                 </div>
-                <div className="border-fuego-700/25 rounded-lg border">
+                <div className="border-fuego-700/25 max-w-xl rounded-lg border">
                   <iframe
                     // src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2695.327326328058!2d19.052879476329124!3d47.50301627118055!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4741dc5d208bb3a7%3A0xc5311960d2e1452d!2sGreen%20Point%20Beauty!5e0!3m2!1sen!2shu!4v1766956749972!5m2!1sen!2shu"
                     src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d673.8318315820144!2d19.054810666706768!3d47.50301627118057!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4741dc5d208bb3a7%3A0xc5311960d2e1452d!2sGreen%20Point%20Beauty!5e0!3m2!1sen!2shu!4v1766957080319!5m2!1sen!2shu"

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -81,6 +81,7 @@ const NAVIGATION_QUERY = defineQuery(`*[_type == 'navigation'][0]{
         name,
         shortDescription,
         "slug": slug.current,
+        "pageType": _type,
         mainImage
       }
     }

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -43,6 +43,16 @@ export const fetchTreatmentBySlug = async (slug: string) => {
   return sanityFetch({ query: SINGLE_TREATMENT_QUERY, params: { slug } });
 };
 
+const CUSTOM_PAGE_QUERY =
+  defineQuery(`*[_type == 'customPage' && slug.current == $slug][0]{
+  title,
+  content
+}`);
+
+export const fetchCustomPageBySlug = async (slug: string) => {
+  return sanityFetch({ query: CUSTOM_PAGE_QUERY, params: { slug } });
+};
+
 const NAVIGATION_QUERY = defineQuery(`*[_type == 'navigation'][0]{
   navMenuItems[]{
     _id,
@@ -61,6 +71,7 @@ const NAVIGATION_QUERY = defineQuery(`*[_type == 'navigation'][0]{
           name,
           shortDescription,
           "slug": slug.current,
+          "pageType": _type,
           mainImage
         }
       }

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -64,6 +64,12 @@ const NAVIGATION_QUERY = defineQuery(`*[_type == 'navigation'][0]{
         "url": externalLink
       }
     },
+    mode == "link" && linkType == "static" => {
+      "link": {
+        "type": "static",
+        "path": staticPath
+      }
+    },
     mode == "link" && linkType == "internal" => {
       "link": {
         "type": "internal",

--- a/src/sanity/schemaTypes/components/SlugWithUrl.tsx
+++ b/src/sanity/schemaTypes/components/SlugWithUrl.tsx
@@ -2,12 +2,17 @@ import { CopyIcon, LaunchIcon } from '@sanity/icons';
 import { Button, Card, Flex, Stack, Text, Tooltip, useToast } from '@sanity/ui';
 import { type SlugInputProps, useFormValue } from 'sanity';
 
-export const SlugWithUrlInput = (props: SlugInputProps) => {
+export type SlugWithUrlInputProps = SlugInputProps & {
+  basePath: string;
+};
+
+export const SlugWithUrlInput = (props: SlugWithUrlInputProps) => {
   const toast = useToast();
   const _id = useFormValue(['_id']) as string;
   const slug = props.value?.current;
+  const basePath = props.basePath.replace(/^\/|\/$/g, '');
   const isPublished = _id && !_id.startsWith('drafts.');
-  const url = slug ? `${window.location.origin}/kezelesek/${slug}` : '';
+  const url = slug ? `${window.location.origin}/${basePath}/${slug}` : '';
 
   const handleCopy = () => {
     navigator.clipboard
@@ -76,3 +81,13 @@ export const SlugWithUrlInput = (props: SlugInputProps) => {
     </Stack>
   );
 };
+
+/**
+ * Returns a SlugWithUrlInput with a fixed basePath for use in schema definitions.
+ * Use this when you want the URL preview to show a specific path prefix (e.g. "p" for /p/slug).
+ */
+export function createSlugWithUrlInput(basePath: string) {
+  return function SlugWithUrlInputWithBasePath(props: SlugInputProps) {
+    return <SlugWithUrlInput {...props} basePath={basePath} />;
+  };
+}

--- a/src/sanity/schemaTypes/components/SlugWithUrl.tsx
+++ b/src/sanity/schemaTypes/components/SlugWithUrl.tsx
@@ -6,7 +6,7 @@ export type SlugWithUrlInputProps = SlugInputProps & {
   basePath: string;
 };
 
-export const SlugWithUrlInput = (props: SlugWithUrlInputProps) => {
+const SlugWithUrlInput = (props: SlugWithUrlInputProps) => {
   const toast = useToast();
   const _id = useFormValue(['_id']) as string;
   const slug = props.value?.current;

--- a/src/sanity/schemaTypes/customPageType.ts
+++ b/src/sanity/schemaTypes/customPageType.ts
@@ -1,0 +1,37 @@
+import { defineType, defineField } from 'sanity';
+
+import { createSlugWithUrlInput } from '@/sanity/schemaTypes/components/SlugWithUrl';
+
+export const customPageType = defineType({
+  name: 'customPage',
+  title: 'Egyedi landing oldalak',
+  type: 'document',
+  icon: () => '📄',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Cím',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      type: 'slug',
+      title: 'Slug',
+      options: {
+        source: 'title',
+      },
+      validation: (Rule) => Rule.required(),
+      components: {
+        input: createSlugWithUrlInput('p'),
+      },
+    }),
+    defineField({
+      name: 'content',
+      title: 'Tartalom',
+      type: 'array',
+      of: [{ type: 'block' }],
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+});

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -1,6 +1,7 @@
 import { type SchemaPluginOptions } from 'sanity';
 
 import { blockContentType } from '@/sanity/schemaTypes/blockContentType';
+import { customPageType } from '@/sanity/schemaTypes/customPageType';
 import { homePage } from '@/sanity/schemaTypes/singletons/homePage';
 import { navigation } from '@/sanity/schemaTypes/singletons/navigation';
 import { treatmentType } from '@/sanity/schemaTypes/treatmentType';
@@ -8,7 +9,13 @@ import { treatmentType } from '@/sanity/schemaTypes/treatmentType';
 export const singletonTypes = new Set(['homePage', 'navigation']);
 
 export const schema: SchemaPluginOptions = {
-  types: [blockContentType, homePage, treatmentType, navigation],
+  types: [
+    blockContentType,
+    homePage,
+    treatmentType,
+    navigation,
+    customPageType,
+  ],
   templates: (templates) =>
     templates.filter(({ schemaType }) => !singletonTypes.has(schemaType)),
 };

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -4,6 +4,7 @@ import { blockContentType } from '@/sanity/schemaTypes/blockContentType';
 import { customPageType } from '@/sanity/schemaTypes/customPageType';
 import { homePage } from '@/sanity/schemaTypes/singletons/homePage';
 import { navigation } from '@/sanity/schemaTypes/singletons/navigation';
+import { treatmentCategoryType } from '@/sanity/schemaTypes/treatmentCategoryType';
 import { treatmentType } from '@/sanity/schemaTypes/treatmentType';
 
 export const singletonTypes = new Set(['homePage', 'navigation']);
@@ -12,6 +13,7 @@ export const schema: SchemaPluginOptions = {
   types: [
     blockContentType,
     homePage,
+    treatmentCategoryType,
     treatmentType,
     navigation,
     customPageType,

--- a/src/sanity/schemaTypes/singletons/navigation.ts
+++ b/src/sanity/schemaTypes/singletons/navigation.ts
@@ -64,7 +64,7 @@ export const navigation = defineType({
               name: 'internalLink',
               title: 'Belső hivatkozás',
               type: 'reference',
-              to: [{ type: 'treatment' }],
+              to: [{ type: 'treatment' }, { type: 'customPage' }],
               hidden: ({ parent }) => parent?.linkType !== 'internal',
               validation: (Rule) =>
                 Rule.custom((value, context) => {

--- a/src/sanity/schemaTypes/singletons/navigation.ts
+++ b/src/sanity/schemaTypes/singletons/navigation.ts
@@ -47,6 +47,7 @@ export const navigation = defineType({
                 list: [
                   { title: 'Belső hivatkozás', value: 'internal' },
                   { title: 'Külső hivatkozás', value: 'external' },
+                  { title: 'Statikus belső oldal', value: 'static' },
                 ],
                 layout: 'radio',
               },
@@ -79,12 +80,28 @@ export const navigation = defineType({
               name: 'externalLink',
               title: 'Külső hivatkozás',
               type: 'url',
+              description: 'Teljes URL https-el, pl. https://www.greenpoint.hu',
               hidden: ({ parent }) => parent?.linkType !== 'external',
               validation: (Rule) =>
                 Rule.custom((value, context) => {
                   const parent = context.parent as { linkType: string };
                   if (parent?.linkType === 'external' && !value) {
                     return 'Add meg a külső URL-t!';
+                  }
+                  return true;
+                }),
+            }),
+            defineField({
+              name: 'staticPath',
+              title: 'Statikus útvonal',
+              type: 'string',
+              description: 'Pl. /arlista',
+              hidden: ({ parent }) => parent?.linkType !== 'static',
+              validation: (Rule) =>
+                Rule.custom((value, context) => {
+                  const parent = context.parent as { linkType: string };
+                  if (parent?.linkType === 'static' && !value) {
+                    return 'Add meg az útvonalat!';
                   }
                   return true;
                 }),

--- a/src/sanity/schemaTypes/singletons/navigation.ts
+++ b/src/sanity/schemaTypes/singletons/navigation.ts
@@ -2,7 +2,7 @@ import { defineType, defineField, defineArrayMember } from 'sanity';
 
 export const navigation = defineType({
   name: 'navigation',
-  title: 'Főmenü',
+  title: 'Navigáció',
   type: 'document',
   icon: () => '🔀',
   fields: [
@@ -121,7 +121,7 @@ export const navigation = defineType({
   preview: {
     prepare() {
       return {
-        title: 'Főmenü',
+        title: 'Navigáció',
       };
     },
   },

--- a/src/sanity/schemaTypes/treatmentCategoryType.ts
+++ b/src/sanity/schemaTypes/treatmentCategoryType.ts
@@ -1,0 +1,25 @@
+import { defineField, defineType } from 'sanity';
+
+export const treatmentCategoryType = defineType({
+  name: 'treatmentCategory',
+  title: 'Kezelés kategóriák',
+  type: 'document',
+  icon: () => '🏷️',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Név',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'name',
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+});

--- a/src/sanity/schemaTypes/treatmentType.ts
+++ b/src/sanity/schemaTypes/treatmentType.ts
@@ -61,6 +61,13 @@ export const treatmentType = defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'category',
+      title: 'Kategória',
+      type: 'reference',
+      to: [{ type: 'treatmentCategory' }],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
       name: 'details',
       type: 'array',
       title: 'Részletes leírás',

--- a/src/sanity/schemaTypes/treatmentType.ts
+++ b/src/sanity/schemaTypes/treatmentType.ts
@@ -1,6 +1,6 @@
 import { defineType, defineField } from 'sanity';
 
-import { SlugWithUrlInput } from '@/sanity/schemaTypes/components/SlugWithUrl';
+import { createSlugWithUrlInput } from '@/sanity/schemaTypes/components/SlugWithUrl';
 
 export const treatmentType = defineType({
   name: 'treatment',
@@ -23,7 +23,7 @@ export const treatmentType = defineType({
       },
       validation: (Rule) => Rule.required(),
       components: {
-        input: SlugWithUrlInput,
+        input: createSlugWithUrlInput('kezelesek'),
       },
     }),
     defineField({

--- a/src/sanity/structure.ts
+++ b/src/sanity/structure.ts
@@ -9,7 +9,7 @@ export const structure: StructureResolver = (S) =>
       S.listItem()
         .id('navigation')
         .schemaType('navigation')
-        .title('Főmenü')
+        .title('Navigáció')
         .child(
           S.editor()
             .id('navigation')


### PR DESCRIPTION
## Summary
- Adds a new `customPage` Sanity document type for arbitrary landing pages managed in the CMS
- Adds `/p/[slug]` route that renders custom pages via PortableText
- Adds `/arlista` route stub for the price list page
- Updates `SlugWithUrl` component to accept a dynamic base path
- Updates desktop navigation to route internal links to the correct path based on document type (`/kezelesek/[slug]` for treatments, `/p/[slug]` for custom pages)

## Test plan
- [x] Create a custom page document in Sanity and verify it renders at `/p/[slug]`
- [x] Add an internal nav link pointing to a custom page and verify it routes to `/p/[slug]`
- [x] Add an internal nav link pointing to a treatment and verify it still routes to `/kezelesek/[slug]`
- [x] Verify `/arlista` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)